### PR TITLE
Document Firebase Hosting live site and adjust mobile Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 The Food Mutiny
 A lightweight, single-page web app for mindful food tracking, powered by Firebase. This app allows users to create an account, save their food log to the cloud, and access it from any device.
 
+## Live Site
+
+The production app is deployed to Firebase Hosting via GitHub Actions and is available at [https://mcfattys-food-tracker.web.app](https://mcfattys-food-tracker.web.app).
+
 Core Philosophy
 Slow and steady wins the race. The Food Mutiny is not about calorie counting, restrictions, or guilt. It's about the simple, mindful act of recording what you eat without judgment. This app will always be free, without subscriptions or upsells.
 

--- a/js/main.js
+++ b/js/main.js
@@ -1559,10 +1559,11 @@ const isStandalonePwa = () => {
 };
 
 const shouldUseRedirectAuth = () => {
-  const smallViewport = window.matchMedia('(max-width: 768px)').matches;
-  const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-  const mobileUserAgent = /iphone|ipod|ipad|android/i.test(navigator.userAgent);
-  return isStandalonePwa() || smallViewport || isTouchDevice || mobileUserAgent;
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isIOS = /iphone|ipad|ipod/.test(userAgent);
+  const isSafari = /^((?!chrome|android).)*safari/.test(userAgent);
+  const inAppBrowser = /(fban|fbav|instagram|line|micromessenger)/.test(userAgent);
+  return isStandalonePwa() || isIOS || isSafari || inAppBrowser;
 };
 
 const setupEventListeners = (tileSystem) => {
@@ -1624,6 +1625,9 @@ const setupEventListeners = (tileSystem) => {
         return;
       }
       const provider = new GoogleAuthProvider();
+      if (typeof provider.setCustomParameters === 'function') {
+        provider.setCustomParameters({ prompt: 'select_account' });
+      }
       const useRedirect = shouldUseRedirectAuth();
       try {
         if (useRedirect && typeof signInWithRedirect === 'function') {


### PR DESCRIPTION
## Summary
- add a live site section in the README pointing to the Firebase Hosting deployment managed via GitHub Actions
- refine the Google sign-in flow to prefer popups on mobile browsers that support them and require explicit account selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da26ec355c832c8e495c75ecc43620